### PR TITLE
Add HTTP timeouts and tighten downloader sanitization

### DIFF
--- a/src/tests/test_downloader.py
+++ b/src/tests/test_downloader.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from zoom_scribe.downloader import RecordingDownloader
+from zoom_scribe.downloader import RecordingDownloader, _sanitize
 from zoom_scribe.models import Recording
 
 
@@ -113,3 +113,8 @@ def test_download_in_dry_run_mode(monkeypatch, sample_recording):
     downloader.download([sample_recording], "/downloads", dry_run=True, overwrite=False)
 
     client.download_file.assert_not_called()
+
+
+@pytest.mark.parametrize("value", [".", "..", "...", "...."])
+def test_sanitize_replaces_dot_only_values(value):
+    assert _sanitize(value) == "_"


### PR DESCRIPTION
## Summary
- add a configurable timeout to `ZoomAPIClient`, propagate it to all HTTP calls, and guard against refreshing expired tokens without credentials
- allow per-request overrides for download timeouts and validate timeout inputs while keeping retry logic intact
- harden downloader sanitization and streaming helpers and extend the unit tests to cover timeout behavior and dot-only paths

## Testing
- ruff format .
- ruff check .
- pytest
- pyright

------
https://chatgpt.com/codex/tasks/task_e_68d9f84de908832e95ff35f0812285df