### PR TITLE
Refactor: Centralize configuration and simplify codebase

### DIFF
--- a/src/tests/test_downloader.py
+++ b/src/tests/test_downloader.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from zoom_scribe.config import DownloaderConfig
 from zoom_scribe.downloader import DownloadError, RecordingDownloader, _sanitize
 from zoom_scribe.models import Recording
 
@@ -31,10 +32,13 @@ def sample_recording() -> Recording:
 
 
 def test_build_file_path_sanitizes_components(sample_recording: Recording) -> None:
-    downloader = RecordingDownloader(Mock())
-    recording_file = sample_recording.recording_files[0]
+    config = DownloaderConfig()
+    downloader = RecordingDownloader(Mock(), config=config)
+    recording_file = sample_recording.files[0]
 
-    destination = downloader.build_file_path(sample_recording, recording_file, "/downloads")
+    destination = downloader.build_file_path(
+        sample_recording, recording_file, Path("/downloads")
+    )
 
     path_str = destination.as_posix()
     assert "/downloads" in path_str
@@ -48,55 +52,61 @@ def test_download_creates_directories_and_writes_files(
     tmp_path: Path, sample_recording: Recording
 ) -> None:
     client = Mock()
-    client.download_file.return_value = b"binary-data"
-    downloader = RecordingDownloader(client, max_workers=1)
+    client.download_recording_file.return_value = b"binary-data"
+    config = DownloaderConfig(target_dir=tmp_path)
+    downloader = RecordingDownloader(client, config=config, max_workers=1)
 
-    downloader.download([sample_recording], tmp_path, dry_run=False, overwrite=False)
+    downloader.download([sample_recording])
 
-    recording_file = sample_recording.recording_files[0]
+    recording_file = sample_recording.files[0]
     destination = downloader.build_file_path(sample_recording, recording_file, tmp_path)
     assert destination.exists()
     assert destination.read_bytes() == b"binary-data"
     assert not destination.with_suffix(destination.suffix + ".part").exists()
-    client.download_file.assert_called_once()
+    client.download_recording_file.assert_called_once()
 
 
 def test_download_skips_existing_file_without_overwrite(
     tmp_path: Path, sample_recording: Recording
 ) -> None:
     client = Mock()
-    downloader = RecordingDownloader(client, max_workers=1)
+    config = DownloaderConfig(target_dir=tmp_path, overwrite=False)
+    downloader = RecordingDownloader(client, config=config, max_workers=1)
 
-    recording_file = sample_recording.recording_files[0]
+    recording_file = sample_recording.files[0]
     destination = downloader.build_file_path(sample_recording, recording_file, tmp_path)
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.write_bytes(b"existing")
 
-    downloader.download([sample_recording], tmp_path, dry_run=False, overwrite=False)
+    downloader.download([sample_recording])
 
-    client.download_file.assert_not_called()
+    client.download_recording_file.assert_not_called()
     assert destination.read_bytes() == b"existing"
 
 
-def test_download_overwrites_when_requested(tmp_path: Path, sample_recording: Recording) -> None:
+def test_download_overwrites_when_requested(
+    tmp_path: Path, sample_recording: Recording
+) -> None:
     client = Mock()
-    client.download_file.return_value = b"new-data"
-    downloader = RecordingDownloader(client, max_workers=1)
+    client.download_recording_file.return_value = b"new-data"
+    config = DownloaderConfig(target_dir=tmp_path, overwrite=True)
+    downloader = RecordingDownloader(client, config=config, max_workers=1)
 
-    recording_file = sample_recording.recording_files[0]
+    recording_file = sample_recording.files[0]
     destination = downloader.build_file_path(sample_recording, recording_file, tmp_path)
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.write_bytes(b"old-data")
 
-    downloader.download([sample_recording], tmp_path, dry_run=False, overwrite=True)
+    downloader.download([sample_recording])
 
-    client.download_file.assert_called_once()
+    client.download_recording_file.assert_called_once()
     assert destination.read_bytes() == b"new-data"
 
 
 def test_download_in_dry_run_mode(tmp_path: Path, sample_recording: Recording) -> None:
     client = Mock()
-    downloader = RecordingDownloader(client, max_workers=1)
+    config = DownloaderConfig(target_dir=tmp_path, dry_run=True)
+    downloader = RecordingDownloader(client, config=config, max_workers=1)
 
     hook_called = False
 
@@ -106,14 +116,11 @@ def test_download_in_dry_run_mode(tmp_path: Path, sample_recording: Recording) -
 
     downloader.download(
         [sample_recording],
-        tmp_path,
-        dry_run=True,
-        overwrite=False,
         post_download=hook,
     )
 
-    client.download_file.assert_not_called()
-    recording_file = sample_recording.recording_files[0]
+    client.download_recording_file.assert_not_called()
+    recording_file = sample_recording.files[0]
     destination = downloader.build_file_path(sample_recording, recording_file, tmp_path)
     assert not destination.exists()
     assert hook_called is False
@@ -125,10 +132,11 @@ def test_download_cleans_temp_on_failure(
     sample_recording: Recording,
 ) -> None:
     client = Mock()
-    client.download_file.return_value = b"binary-data"
-    downloader = RecordingDownloader(client, max_workers=1)
+    client.download_recording_file.return_value = b"binary-data"
+    config = DownloaderConfig(target_dir=tmp_path)
+    downloader = RecordingDownloader(client, config=config, max_workers=1)
 
-    recording_file = sample_recording.recording_files[0]
+    recording_file = sample_recording.files[0]
     destination = downloader.build_file_path(sample_recording, recording_file, tmp_path)
     destination.parent.mkdir(parents=True, exist_ok=True)
 
@@ -138,7 +146,7 @@ def test_download_cleans_temp_on_failure(
     monkeypatch.setattr(Path, "replace", fail_replace)
 
     with pytest.raises(DownloadError):
-        downloader.download([sample_recording], tmp_path, dry_run=False, overwrite=False)
+        downloader.download([sample_recording])
 
     temp_path = destination.with_suffix(destination.suffix + ".part")
     assert not temp_path.exists()
@@ -165,7 +173,7 @@ def test_concurrent_downloads_are_thread_safe(tmp_path: Path) -> None:
         time.sleep(0.01)
         return b"data"
 
-    client.download_file.side_effect = download_with_delay
+    client.download_recording_file.side_effect = download_with_delay
 
     # Create multiple recordings to download in parallel
     recordings: list[Recording] = []
@@ -187,25 +195,29 @@ def test_concurrent_downloads_are_thread_safe(tmp_path: Path) -> None:
         }
         recordings.append(Recording.from_api(payload))
 
-    downloader = RecordingDownloader(client, max_workers=3)
-    downloader.download(recordings, tmp_path, dry_run=False, overwrite=False)
+    config = DownloaderConfig(target_dir=tmp_path)
+    downloader = RecordingDownloader(client, config=config, max_workers=3)
+    downloader.download(recordings)
 
     # Verify all files were downloaded
     assert call_count == 5
-    assert client.download_file.call_count == 5
+    assert client.download_recording_file.call_count == 5
 
     # Verify all files exist on disk
     for recording in recordings:
-        recording_file = recording.recording_files[0]
+        recording_file = recording.files[0]
         destination = downloader.build_file_path(recording, recording_file, tmp_path)
         assert destination.exists()
         assert destination.read_bytes() == b"data"
 
 
-def test_download_invokes_post_download_hook(tmp_path: Path, sample_recording: Recording) -> None:
+def test_download_invokes_post_download_hook(
+    tmp_path: Path, sample_recording: Recording
+) -> None:
     client = Mock()
-    client.download_file.return_value = b"binary-data"
-    downloader = RecordingDownloader(client, max_workers=1)
+    client.download_recording_file.return_value = b"binary-data"
+    config = DownloaderConfig(target_dir=tmp_path)
+    downloader = RecordingDownloader(client, config=config, max_workers=1)
     calls: list[Path] = []
 
     def hook(path: Path, *_args: Any) -> None:
@@ -213,13 +225,12 @@ def test_download_invokes_post_download_hook(tmp_path: Path, sample_recording: R
 
     downloader.download(
         [sample_recording],
-        tmp_path,
-        dry_run=False,
-        overwrite=False,
         post_download=hook,
     )
 
     assert calls
-    recording_file = sample_recording.recording_files[0]
-    expected_path = downloader.build_file_path(sample_recording, recording_file, tmp_path)
+    recording_file = sample_recording.files[0]
+    expected_path = downloader.build_file_path(
+        sample_recording, recording_file, tmp_path
+    )
     assert calls[0] == expected_path

--- a/src/zoom_scribe/config.py
+++ b/src/zoom_scribe/config.py
@@ -1,11 +1,14 @@
-"""Environment configuration utilities for Zoom S2S OAuth credentials."""
+"""Configuration models and utilities for ZoomScribe."""
 
 from __future__ import annotations
 
 import os
 from collections.abc import Mapping, MutableMapping
-from dataclasses import dataclass
-from typing import IO, cast
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import IO, Any, cast
+
+from .screenshare.preprocess import PreprocessConfig
 
 try:  # pragma: no cover - imported lazily in production environments
     from dotenv import find_dotenv, load_dotenv
@@ -48,6 +51,43 @@ def _mask(value: str) -> str:
     if len(value) <= REDACTION_SUFFIX_LENGTH:
         return "***"
     return f"***{value[-REDACTION_SUFFIX_LENGTH:]}"
+
+
+@dataclass(frozen=True, slots=True)
+class LoggingConfig:
+    """Structured logging configuration."""
+
+    level: str = "info"
+    format: str = "auto"
+
+
+@dataclass(frozen=True, slots=True)
+class DownloaderConfig:
+    """Configuration for the recording asset downloader."""
+
+    target_dir: Path = field(default_factory=lambda: Path("downloads"))
+    overwrite: bool = False
+    dry_run: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ScreenshareConfig:
+    """Configuration for screenshare preprocessing."""
+
+    enabled: bool = False
+    output_dir: Path | None = None
+    preprocess_config: PreprocessConfig = field(default_factory=PreprocessConfig)
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Unified application configuration."""
+
+    credentials: OAuthCredentials
+    logging: LoggingConfig = field(default_factory=LoggingConfig)
+    downloader: DownloaderConfig = field(default_factory=DownloaderConfig)
+    screenshare: ScreenshareConfig = field(default_factory=ScreenshareConfig)
+    client_overrides: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -150,4 +190,8 @@ __all__ = [
     "ConfigurationError",
     "OAuthCredentials",
     "load_oauth_credentials",
+    "Config",
+    "LoggingConfig",
+    "DownloaderConfig",
+    "ScreenshareConfig",
 ]

--- a/src/zoom_scribe/downloader.py
+++ b/src/zoom_scribe/downloader.py
@@ -13,16 +13,12 @@ from pathlib import Path
 from typing import IO, Any, Protocol, runtime_checkable
 
 from ._redact import redact_identifier, redact_uuid
+from .client import ZoomAPIClient
+from .config import DownloaderConfig
 from .models import Recording, RecordingFile
 
 _SANITIZE_PATTERN = re.compile(r"[^A-Za-z0-9._@-]")
 _PART_SUFFIX = ".part"
-
-
-@runtime_checkable
-class _Readable(Protocol):
-    def read(self) -> bytes:
-        """Return the bytes content for a stream-like object."""
 
 
 class DownloadError(RuntimeError):
@@ -46,14 +42,16 @@ class RecordingDownloader:
 
     def __init__(
         self,
-        client: Any,
+        client: ZoomAPIClient,
         *,
+        config: DownloaderConfig,
         logger: logging.Logger | None = None,
         max_workers: int = 2,
         progress_stream: IO[str] | None = None,
     ) -> None:
         """Initialise the downloader with a client capable of fetching bytes."""
         self.client = client
+        self.config = config
         self.logger = logger or logging.getLogger(__name__)
         self.max_workers = max(1, int(max_workers))
         self._progress_stream = progress_stream or sys.stderr
@@ -63,15 +61,14 @@ class RecordingDownloader:
         self,
         recording: Recording,
         recording_file: RecordingFile,
-        target_dir: str | Path,
+        target_dir: Path,
     ) -> Path:
         """Return the destination path for a recording file within ``target_dir``."""
-        target = Path(target_dir)
         start = recording.start_time
         host_dir = _sanitize(recording.host_email)
         topic_dir = _sanitize(f"{recording.meeting_topic}-{recording.uuid}")
         dated_path = (
-            target
+            target_dir
             / host_dir
             / f"{start.year:04d}"
             / f"{start.month:02d}"
@@ -79,34 +76,29 @@ class RecordingDownloader:
             / topic_dir
         )
         timestamp = start.strftime("%Y-%m-%dT%H-%M-%S")
-        extension = recording_file.file_extension.lstrip(".")
+        extension = recording_file.file_extension.lstrip(".").lower()
         filename = f"{recording_file.file_type}-{timestamp}.{extension}"
         return dated_path / filename
 
     def download(
         self,
         recordings: Sequence[Recording],
-        target_dir: str | Path,
         *,
-        dry_run: bool = False,
-        overwrite: bool = False,
         post_download: PostDownloadHook | None = None,
     ) -> None:
         """Download the supplied recordings into ``target_dir`` respecting flags.
 
         Args:
             recordings: Collection of meeting recordings to persist.
-            target_dir: Root directory used for on-disk storage.
-            dry_run: When ``True`` no files are written, only progress is logged.
-            overwrite: When ``True`` existing files are replaced with freshly
-                downloaded data.
             post_download: Optional callback invoked after each recording file is
                 processed (including skips). Not executed during dry runs.
         """
-        if dry_run:
+        if self.config.dry_run:
             for recording in recordings:
-                for recording_file in recording.recording_files:
-                    destination = self.build_file_path(recording, recording_file, target_dir)
+                for recording_file in recording.files:
+                    destination = self.build_file_path(
+                        recording, recording_file, self.config.target_dir
+                    )
                     self._log_progress(
                         "dry_run",
                         destination,
@@ -118,14 +110,16 @@ class RecordingDownloader:
         futures: dict[Future[Path], tuple[Recording, RecordingFile, Path]] = {}
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             for recording in recordings:
-                for recording_file in recording.recording_files:
-                    destination = self.build_file_path(recording, recording_file, target_dir)
+                for recording_file in recording.files:
+                    destination = self.build_file_path(
+                        recording, recording_file, self.config.target_dir
+                    )
                     future = executor.submit(
                         self._download_single,
                         recording,
                         recording_file,
                         destination,
-                        overwrite,
+                        self.config.overwrite,
                         post_download,
                     )
                     futures[future] = (recording, recording_file, destination)
@@ -162,8 +156,8 @@ class RecordingDownloader:
 
         try:
             with temp_path.open("wb") as temp_file:
-                for chunk in self._download_contents(recording_file):
-                    temp_file.write(chunk)
+                contents = self._download_contents(recording_file)
+                temp_file.write(contents)
                 temp_file.flush()
                 os.fsync(temp_file.fileno())
             temp_path.replace(destination)
@@ -199,36 +193,9 @@ class RecordingDownloader:
                 },
             )
 
-    def _download_contents(self, recording_file: RecordingFile) -> Iterable[bytes]:
-        """Yield the binary payload for ``recording_file`` in chunks."""
-        download_file = getattr(self.client, "download_file", None)
-        if callable(download_file):
-            data = download_file(
-                url=recording_file.download_url,
-                access_token=recording_file.download_access_token,
-            )
-        else:
-            data = self.client.download_recording_file(recording_file)
-        yield from self._iterate_bytes(data)
-
-    def _iterate_bytes(self, data: Any) -> Iterable[bytes]:
-        """Normalise download payloads into a byte iterator."""
-        if isinstance(data, (bytes, bytearray, memoryview)):
-            yield bytes(data)
-            return
-        if isinstance(data, _Readable):
-            chunk = data.read()
-            if not isinstance(chunk, (bytes, bytearray, memoryview)):
-                raise TypeError("Stream read must return bytes-like data")
-            yield bytes(chunk)
-            return
-        if isinstance(data, Iterable):
-            for chunk in data:
-                if not isinstance(chunk, (bytes, bytearray, memoryview)):
-                    raise TypeError("Download chunks must be bytes-like")
-                yield bytes(chunk)
-            return
-        raise TypeError("Expected bytes or iterable of bytes from client download")
+    def _download_contents(self, recording_file: RecordingFile) -> bytes:
+        """Return the binary payload for ``recording_file``."""
+        return self.client.download_recording_file(recording_file)
 
     def _log_progress(
         self,

--- a/src/zoom_scribe/models.py
+++ b/src/zoom_scribe/models.py
@@ -182,14 +182,6 @@ class Recording:
             recording_files=files,
         )
 
-    def iter_files(self) -> tuple[RecordingFile, ...]:
-        """Return the recording files as an immutable tuple.
-
-        Returns:
-            Tuple containing each ``RecordingFile`` associated with the meeting.
-        """
-        return self.recording_files
-
     @property
     def files(self) -> tuple[RecordingFile, ...]:
         """Alias for :attr:`recording_files` to aid readability."""


### PR DESCRIPTION
This commit introduces a major refactoring to improve the application's structure and maintainability.

The key changes are:
- A unified `Config` object has been introduced in `src/zoom_scribe/config.py` to centralize all application settings, including OAuth credentials, downloader options, and logging settings.
- The CLI in `main.py` has been simplified to build this `Config` object at startup, which is then passed to the relevant components.
- The `ZoomAPIClient` and `RecordingDownloader` have been updated to accept the `Config` object, simplifying their initialization and removing the need to pass around individual settings.
- Redundant code, such as the `iter_files` method in the `Recording` model, has been removed.
- The test suite has been updated to reflect all refactoring changes.