### PR TITLE
Add web frontend and FastAPI adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /usr/bin/env bash
 
-.PHONY: lint
+.PHONY: lint web-dev web-build serve-api serve-all
 lint:
 	@set -euo pipefail; \
 	if [[ -n "${VIRTUAL_ENV:-}" ]]; then PYTHON="$$VIRTUAL_ENV/bin/python"; \
@@ -19,3 +19,27 @@ lint:
 		if command -v shellcheck >/dev/null 2>&1; then shellcheck $$sh_files; else echo "shellcheck not found, skipping"; fi; \
 		if command -v shfmt >/dev/null 2>&1; then shfmt -d -i 4 -ci -sr $$sh_files; else echo "shfmt not found, skipping"; fi; \
 	else echo "No shell scripts to lint"; fi
+
+web-dev:
+	@set -euo pipefail; \
+	cd web; \
+	if [[ ! -d node_modules ]]; then pnpm install --frozen-lockfile; fi; \
+	pnpm dev
+
+web-build:
+	@set -euo pipefail; \
+	cd web; \
+	pnpm install --frozen-lockfile; \
+	pnpm build
+
+serve-api:
+	@uvicorn zoom_scribe.web_api:app --reload
+
+serve-all:
+	@set -euo pipefail; \
+	uvicorn zoom_scribe.web_api:app --reload & \
+	backend_pid=$$!; \
+	trap "kill $$backend_pid" INT TERM EXIT; \
+	cd web; \
+	pnpm install --frozen-lockfile; \
+	pnpm dev

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ black
 isort
 mypy
 pytest
+httpx
 pytest-cov
 ruff
 types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ python-dotenv
 opencv-python-headless==4.9.0.80
 numpy==1.26.4
 scikit-image==0.22.0
+fastapi
+uvicorn[standard]

--- a/src/tests/test_web_api.py
+++ b/src/tests/test_web_api.py
@@ -1,0 +1,160 @@
+"""Tests for the FastAPI web adapter."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from zoom_scribe.config import Config, DownloaderConfig, LoggingConfig, OAuthCredentials
+from zoom_scribe.models import Recording, RecordingFile
+from zoom_scribe.web_api import ApiContext, app, get_api_context
+
+
+class StubZoomClient:
+    """In-memory Zoom client used to stub out network calls."""
+
+    def __init__(self, recordings: list[Recording]) -> None:
+        self._recordings = recordings
+        self.calls: list[dict[str, Any]] = []
+
+    def list_recordings(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        host_email: str | None = None,
+        meeting_id: str | None = None,
+        page_size: int = 100,
+    ) -> list[Recording]:
+        self.calls.append(
+            {
+                "start": start,
+                "end": end,
+                "host_email": host_email,
+                "meeting_id": meeting_id,
+                "page_size": page_size,
+            }
+        )
+        return list(self._recordings)
+
+
+class SpyDownloader:
+    """Spy implementation that records download invocations."""
+
+    def __init__(self, downloader_config: DownloaderConfig) -> None:
+        self.config = downloader_config
+        self.calls: list[list[Recording]] = []
+
+    def download(self, recordings: list[Recording]) -> None:
+        self.calls.append(list(recordings))
+
+
+@pytest.fixture
+def sample_recordings() -> list[Recording]:
+    start = datetime(2024, 1, 5, 15, 30, tzinfo=UTC)
+    files = (
+        RecordingFile(
+            id="file-1",
+            file_type="MP4",
+            file_extension="mp4",
+            download_url="https://zoom.us/recording",
+            file_size=2048,
+        ),
+    )
+    recording = Recording(
+        uuid="uuid-123",
+        meeting_topic="Weekly Sync",
+        host_email="host@example.com",
+        start_time=start,
+        duration_minutes=55,
+        recording_files=files,
+    )
+    return [recording]
+
+
+@pytest.fixture
+def context(sample_recordings: list[Recording]) -> ApiContext:
+    credentials = OAuthCredentials(
+        account_id="acct",
+        client_id="client",
+        client_secret="secret",
+    )
+    config = Config(
+        credentials=credentials,
+        logging=LoggingConfig(level="debug", format="json"),
+        downloader=DownloaderConfig(target_dir=Path("downloads"), overwrite=False, dry_run=False),
+    )
+    client = StubZoomClient(sample_recordings)
+    return ApiContext(config=config, client=client)
+
+
+@pytest.fixture
+def client(context: ApiContext) -> TestClient:
+    app.dependency_overrides[get_api_context] = lambda: context
+    test_client = TestClient(app)
+    try:
+        yield test_client
+    finally:
+        test_client.close()
+        app.dependency_overrides.pop(get_api_context, None)
+
+
+def test_health_endpoint() -> None:
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_list_recordings_returns_summaries(client: TestClient, context: ApiContext) -> None:
+    response = client.get("/api/recordings?from=2024-01-01&to=2024-01-31")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload == [
+        {
+            "uuid": "uuid-123",
+            "meeting_id": None,
+            "topic": "Weekly Sync",
+            "host_email": "host@example.com",
+            "start_time": "2024-01-05T15:30:00Z",
+            "duration_minutes": 55,
+            "asset_count": 1,
+            "total_size_bytes": 2048,
+        }
+    ]
+
+    call = context.client.calls[-1]
+    assert call["host_email"] is None
+    assert call["meeting_id"] is None
+
+
+def test_trigger_download_invokes_downloader(
+    client: TestClient,
+    context: ApiContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spy = SpyDownloader(context.config.downloader)
+
+    def factory(config: Config, _: StubZoomClient) -> SpyDownloader:
+        spy.config = config.downloader
+        return spy
+
+    monkeypatch.setattr("zoom_scribe.web_api.create_downloader", factory)
+
+    response = client.post(
+        "/api/download",
+        json={"meeting_id_or_uuid": "uuid-123", "overwrite": True, "target_dir": "custom"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["ok"] is True
+    assert payload["files_expected"] == 1
+    assert spy.calls and len(spy.calls[0]) == 1
+    assert spy.config.target_dir == Path("custom")
+    assert spy.config.overwrite is True

--- a/src/zoom_scribe/web_api.py
+++ b/src/zoom_scribe/web_api.py
@@ -1,0 +1,260 @@
+"""FastAPI application exposing a lightweight ZoomScribe web interface."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, replace
+from datetime import UTC, date, datetime, time, timedelta
+from pathlib import Path
+from threading import RLock
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+from ._datetime import ensure_utc
+from .client import (
+    MissingCredentialsError,
+    ZoomAPIClient,
+    ZoomAPIError,
+    ZoomAuthError,
+    ZoomNotFoundError,
+    ZoomRateLimitError,
+)
+from .config import (
+    Config,
+    ConfigurationError,
+    DownloaderConfig,
+    LoggingConfig,
+    load_oauth_credentials,
+)
+from .downloader import DownloadError
+from .main import configure_logging, create_client, create_downloader
+from .models import Recording
+from .web_types import ApiError, DownloadRequest, DownloadResponse, RecordingSummary
+
+_LOGGER = logging.getLogger(__name__)
+_ALLOWED_ORIGINS = ["http://localhost:5173"]
+_DEFAULT_RANGE_DAYS = 30
+_DOWNLOAD_MEETING_LOOKBACK_DAYS = 365
+_STATIC_ROOT = Path("web/dist")
+
+
+@dataclass(frozen=True, slots=True)
+class ApiContext:
+    """Container bundling application config and a shared API client."""
+
+    config: Config
+    client: ZoomAPIClient
+
+
+_CONTEXT_LOCK = RLock()
+_CACHED_CONTEXT: ApiContext | None = None
+_LOGGING_INITIALISED = False
+
+app = FastAPI(title="ZoomScribe Web API", version="1.0.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_ALLOWED_ORIGINS,
+    allow_credentials=False,
+    allow_methods=["GET", "POST"],
+    allow_headers=["*"],
+)
+
+if _STATIC_ROOT.exists():
+    app.mount("/", StaticFiles(directory=_STATIC_ROOT, html=True), name="static")
+
+
+@app.get("/api/health")
+def health() -> dict[str, str]:
+    """Return a trivial health payload used by readiness checks."""
+    return {"status": "ok"}
+
+
+def _build_context() -> ApiContext:
+    """Instantiate and cache the shared Config/Zoom client pair."""
+    global _LOGGING_INITIALISED  # noqa: PLW0603
+    credentials = load_oauth_credentials()
+    config = Config(credentials=credentials, logging=LoggingConfig())
+    if not _LOGGING_INITIALISED:
+        configure_logging(config.logging)
+        _LOGGING_INITIALISED = True
+    client = create_client(config)
+    return ApiContext(config, client)
+
+
+def _http_error(status_code: int, message: str, *, code: str | None = None) -> HTTPException:
+    return HTTPException(status_code=status_code, detail={"message": message, "code": code})
+
+
+def _resolve_date_range(
+    from_date: date | None,
+    to_date: date | None,
+) -> tuple[datetime, datetime]:
+    now = datetime.now(UTC)
+    end = datetime.combine(to_date, time.max, tzinfo=UTC) if to_date else now
+    start_default = end - timedelta(days=_DEFAULT_RANGE_DAYS)
+    start = datetime.combine(from_date, time.min, tzinfo=UTC) if from_date else start_default
+    if start > end:
+        raise _http_error(400, "Start date must be on or before end date")
+    return ensure_utc(start, assume_utc_if_naive=True), ensure_utc(end, assume_utc_if_naive=True)
+
+
+def _build_download_config(
+    base: Config,
+    *,
+    target_dir_override: str | None,
+    overwrite: bool | None,
+) -> Config:
+    target_dir = Path(target_dir_override) if target_dir_override else base.downloader.target_dir
+    overwrite_value = base.downloader.overwrite if overwrite is None else overwrite
+    downloader = DownloaderConfig(
+        target_dir=target_dir,
+        overwrite=overwrite_value,
+        dry_run=base.downloader.dry_run,
+    )
+    return replace(base, downloader=downloader)
+
+
+def _fetch_recordings(
+    client: ZoomAPIClient,
+    *,
+    start: datetime,
+    end: datetime,
+    host_email: str | None,
+    meeting_id: str | None,
+) -> list[Recording]:
+    try:
+        recordings = client.list_recordings(
+            start=start,
+            end=end,
+            host_email=host_email,
+            meeting_id=meeting_id,
+        )
+    except MissingCredentialsError as exc:  # pragma: no cover - defensive, should be caught earlier
+        raise _http_error(503, "Missing Zoom OAuth credentials") from exc
+    except ZoomAuthError as exc:
+        raise _http_error(401, "Zoom authentication failed", code="zoom_auth") from exc
+    except ZoomRateLimitError as exc:
+        raise _http_error(
+            429,
+            "Zoom rate limit exceeded; retry later",
+            code="zoom_rate_limit",
+        ) from exc
+    except ZoomNotFoundError as exc:
+        raise _http_error(404, "Recording not found", code="zoom_not_found") from exc
+    except ZoomAPIError as exc:
+        raise _http_error(502, "Zoom API request failed", code="zoom_api") from exc
+    return recordings
+
+
+def get_api_context() -> ApiContext:
+    """Return a cached ApiContext instance, initialising it on first use."""
+    global _CACHED_CONTEXT  # noqa: PLW0603
+    with _CONTEXT_LOCK:
+        if _CACHED_CONTEXT is None:
+            try:
+                _CACHED_CONTEXT = _build_context()
+            except ConfigurationError as exc:
+                raise _http_error(503, "Missing Zoom OAuth credentials") from exc
+        return _CACHED_CONTEXT
+
+
+@app.exception_handler(HTTPException)
+async def handle_http_exception(_: Request, exc: HTTPException) -> JSONResponse:
+    """Normalise HTTPException responses so they always match ApiError."""
+    detail = exc.detail
+    if isinstance(detail, dict):
+        message = str(detail.get("message", "")) or "Unknown error"
+        code = detail.get("code")
+    else:
+        message = str(detail) or "Unknown error"
+        code = None
+    payload = ApiError(message=message, code=code).model_dump()
+    return JSONResponse(status_code=exc.status_code, content=payload)
+
+
+@app.exception_handler(Exception)
+async def handle_unexpected(request: Request, _exc: Exception) -> JSONResponse:
+    """Catch-all exception handler that redacts details from clients."""
+    _LOGGER.exception("web_api.unhandled_exception", extra={"path": request.url.path})
+    payload = ApiError(message="Internal server error").model_dump()
+    return JSONResponse(status_code=500, content=payload)
+
+
+@app.get("/api/recordings", response_model=list[RecordingSummary])
+def list_recordings(
+    context: Annotated[ApiContext, Depends(get_api_context)],
+    from_date: Annotated[date | None, Query(alias="from")] = None,
+    to_date: Annotated[date | None, Query(alias="to")] = None,
+    host_email: str | None = None,
+    meeting_id: str | None = None,
+) -> list[RecordingSummary]:
+    """Return a filtered list of recording summaries."""
+    host_email_normalised = host_email.strip() if host_email else None
+    meeting_id_normalised = meeting_id.strip() if meeting_id else None
+    start, end = _resolve_date_range(from_date, to_date)
+    recordings = _fetch_recordings(
+        context.client,
+        start=start,
+        end=end,
+        host_email=host_email_normalised,
+        meeting_id=meeting_id_normalised,
+    )
+    return [RecordingSummary.from_recording(recording) for recording in recordings]
+
+
+@app.post("/api/download", response_model=DownloadResponse)
+def trigger_download(
+    context: Annotated[ApiContext, Depends(get_api_context)],
+    request: DownloadRequest,
+) -> DownloadResponse:
+    """Trigger a synchronous download of the requested meeting recordings."""
+    meeting_identifier = request.meeting_id_or_uuid.strip()
+    if not meeting_identifier:
+        raise _http_error(400, "meeting_id_or_uuid is required")
+
+    now = datetime.now(UTC)
+    start = now - timedelta(days=_DOWNLOAD_MEETING_LOOKBACK_DAYS)
+    recordings = _fetch_recordings(
+        context.client,
+        start=start,
+        end=now,
+        host_email=None,
+        meeting_id=meeting_identifier,
+    )
+
+    if not recordings:
+        raise _http_error(404, "Recording not found", code="zoom_not_found")
+
+    files_expected = sum(len(recording.files) for recording in recordings)
+    effective_config = _build_download_config(
+        context.config,
+        target_dir_override=request.target_dir,
+        overwrite=request.overwrite,
+    )
+
+    downloader = create_downloader(effective_config, context.client)
+
+    try:
+        downloader.download(recordings)
+    except DownloadError as exc:
+        raise _http_error(
+            500,
+            "Failed to download one or more files",
+            code="download_failed",
+        ) from exc
+
+    notes: list[str] = []
+    if downloader.config.dry_run:
+        notes.append("Dry run enabled; no files written.")
+    if files_expected == 0:
+        notes.append("Recording does not include downloadable files.")
+
+    note = " ".join(notes) if notes else None
+    return DownloadResponse(ok=True, files_expected=files_expected, note=note)
+
+
+__all__ = ["app", "get_api_context"]

--- a/src/zoom_scribe/web_types.py
+++ b/src/zoom_scribe/web_types.py
@@ -1,0 +1,77 @@
+"""Pydantic models shared by the web API and frontend clients."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from .models import Recording
+
+
+class ApiError(BaseModel):
+    """Serialised representation of an API error response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    message: str
+    code: str | None = None
+
+
+class DownloadRequest(BaseModel):
+    """Request payload for triggering a download."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    meeting_id_or_uuid: str
+    overwrite: bool | None = None
+    target_dir: str | None = None
+
+
+class DownloadResponse(BaseModel):
+    """Response describing the outcome of a download trigger."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+    files_expected: int
+    note: str | None = None
+
+
+class RecordingSummary(BaseModel):
+    """Lightweight view of a meeting recording for list views."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    uuid: str
+    meeting_id: str | None
+    topic: str
+    host_email: str | None
+    start_time: datetime
+    duration_minutes: int | None
+    asset_count: int
+    total_size_bytes: int
+
+    @classmethod
+    def from_recording(cls, recording: Recording) -> "RecordingSummary":
+        """Translate a ``Recording`` domain model into a summary for the API."""
+        total_size = sum(file.file_size or 0 for file in recording.files)
+        asset_count = len(recording.files)
+        return cls(
+            uuid=recording.uuid,
+            meeting_id=None,
+            topic=recording.meeting_topic,
+            host_email=recording.host_email or None,
+            start_time=recording.start_time.astimezone(UTC),
+            duration_minutes=recording.duration_minutes,
+            asset_count=asset_count,
+            total_size_bytes=total_size,
+        )
+
+
+__all__ = [
+    "ApiError",
+    "DownloadRequest",
+    "DownloadResponse",
+    "RecordingSummary",
+]

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ZoomScribe Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "zoomscribe-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.64",
+    "@types/react-dom": "^18.2.19",
+    "@vitejs/plugin-react-swc": "^3.5.0",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.10"
+  }
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1,0 +1,756 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  react:
+    specifier: ^18.2.0
+    version: 18.3.1
+  react-dom:
+    specifier: ^18.2.0
+    version: 18.3.1(react@18.3.1)
+
+devDependencies:
+  '@types/react':
+    specifier: ^18.2.64
+    version: 18.3.25
+  '@types/react-dom':
+    specifier: ^18.2.19
+    version: 18.3.7(@types/react@18.3.25)
+  '@vitejs/plugin-react-swc':
+    specifier: ^3.5.0
+    version: 3.11.0(vite@5.4.20)
+  typescript:
+    specifier: ^5.4.5
+    version: 5.9.3
+  vite:
+    specifier: ^5.2.10
+    version: 5.4.20
+
+packages:
+
+  /@esbuild/aix-ppc64@0.21.5:
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.21.5:
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.21.5:
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.21.5:
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.21.5:
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.21.5:
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.21.5:
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.21.5:
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.21.5:
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.21.5:
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.21.5:
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.21.5:
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.21.5:
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.21.5:
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.21.5:
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.21.5:
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.21.5:
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.21.5:
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.21.5:
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.21.5:
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.21.5:
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.21.5:
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.21.5:
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/pluginutils@1.0.0-beta.27:
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+    dev: true
+
+  /@rollup/rollup-android-arm-eabi@4.52.3:
+    resolution: {integrity: sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.52.3:
+    resolution: {integrity: sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.52.3:
+    resolution: {integrity: sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.52.3:
+    resolution: {integrity: sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-arm64@4.52.3:
+    resolution: {integrity: sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-x64@4.52.3:
+    resolution: {integrity: sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.52.3:
+    resolution: {integrity: sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.52.3:
+    resolution: {integrity: sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.52.3:
+    resolution: {integrity: sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.52.3:
+    resolution: {integrity: sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-loong64-gnu@4.52.3:
+    resolution: {integrity: sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-ppc64-gnu@4.52.3:
+    resolution: {integrity: sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.52.3:
+    resolution: {integrity: sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-musl@4.52.3:
+    resolution: {integrity: sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.52.3:
+    resolution: {integrity: sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.52.3:
+    resolution: {integrity: sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.52.3:
+    resolution: {integrity: sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-openharmony-arm64@4.52.3:
+    resolution: {integrity: sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.52.3:
+    resolution: {integrity: sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.52.3:
+    resolution: {integrity: sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-gnu@4.52.3:
+    resolution: {integrity: sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.52.3:
+    resolution: {integrity: sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-arm64@1.13.5:
+    resolution: {integrity: sha512-lKNv7SujeXvKn16gvQqUQI5DdyY8v7xcoO3k06/FJbHJS90zEwZdQiMNRiqpYw/orU543tPaWgz7cIYWhbopiQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-x64@1.13.5:
+    resolution: {integrity: sha512-ILd38Fg/w23vHb0yVjlWvQBoE37ZJTdlLHa8LRCFDdX4WKfnVBiblsCU9ar4QTMNdeTBEX9iUF4IrbNWhaF1Ng==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm-gnueabihf@1.13.5:
+    resolution: {integrity: sha512-Q6eS3Pt8GLkXxqz9TAw+AUk9HpVJt8Uzm54MvPsqp2yuGmY0/sNaPPNVqctCX9fu/Nu8eaWUen0si6iEiCsazQ==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.13.5:
+    resolution: {integrity: sha512-aNDfeN+9af+y+M2MYfxCzCy/VDq7Z5YIbMqRI739o8Ganz6ST+27kjQFd8Y/57JN/hcnUEa9xqdS3XY7WaVtSw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-musl@1.13.5:
+    resolution: {integrity: sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-gnu@1.13.5:
+    resolution: {integrity: sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-musl@1.13.5:
+    resolution: {integrity: sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-arm64-msvc@1.13.5:
+    resolution: {integrity: sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-ia32-msvc@1.13.5:
+    resolution: {integrity: sha512-C5Yi/xIikrFUzZcyGj9L3RpKljFvKiDMtyDzPKzlsDrKIw2EYY+bF88gB6oGY5RGmv4DAX8dbnpRAqgFD0FMEw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-x64-msvc@1.13.5:
+    resolution: {integrity: sha512-YrKdMVxbYmlfybCSbRtrilc6UA8GF5aPmGKBdPvjrarvsmf4i7ZHGCEnLtfOMd3Lwbs2WUZq3WdMbozYeLU93Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core@1.13.5:
+    resolution: {integrity: sha512-WezcBo8a0Dg2rnR82zhwoR6aRNxeTGfK5QCD6TQ+kg3xx/zNT02s/0o+81h/3zhvFSB24NtqEr8FTw88O5W/JQ==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.25
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.13.5
+      '@swc/core-darwin-x64': 1.13.5
+      '@swc/core-linux-arm-gnueabihf': 1.13.5
+      '@swc/core-linux-arm64-gnu': 1.13.5
+      '@swc/core-linux-arm64-musl': 1.13.5
+      '@swc/core-linux-x64-gnu': 1.13.5
+      '@swc/core-linux-x64-musl': 1.13.5
+      '@swc/core-win32-arm64-msvc': 1.13.5
+      '@swc/core-win32-ia32-msvc': 1.13.5
+      '@swc/core-win32-x64-msvc': 1.13.5
+    dev: true
+
+  /@swc/counter@0.1.3:
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+    dev: true
+
+  /@swc/types@0.1.25:
+    resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
+    dependencies:
+      '@swc/counter': 0.1.3
+    dev: true
+
+  /@types/estree@1.0.8:
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+    dev: true
+
+  /@types/prop-types@15.7.15:
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+    dev: true
+
+  /@types/react-dom@18.3.7(@types/react@18.3.25):
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+    dependencies:
+      '@types/react': 18.3.25
+    dev: true
+
+  /@types/react@18.3.25:
+    resolution: {integrity: sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==}
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.1.3
+    dev: true
+
+  /@vitejs/plugin-react-swc@3.11.0(vite@5.4.20):
+    resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
+    peerDependencies:
+      vite: ^4 || ^5 || ^6 || ^7
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@swc/core': 1.13.5
+      vite: 5.4.20
+    transitivePeerDependencies:
+      - '@swc/helpers'
+    dev: true
+
+  /csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+    dev: true
+
+  /esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+    dev: true
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: false
+
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: false
+
+  /nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
+  /picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    dev: true
+
+  /postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+    dev: true
+
+  /react-dom@18.3.1(react@18.3.1):
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+    dev: false
+
+  /react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
+
+  /rollup@4.52.3:
+    resolution: {integrity: sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.3
+      '@rollup/rollup-android-arm64': 4.52.3
+      '@rollup/rollup-darwin-arm64': 4.52.3
+      '@rollup/rollup-darwin-x64': 4.52.3
+      '@rollup/rollup-freebsd-arm64': 4.52.3
+      '@rollup/rollup-freebsd-x64': 4.52.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.3
+      '@rollup/rollup-linux-arm64-gnu': 4.52.3
+      '@rollup/rollup-linux-arm64-musl': 4.52.3
+      '@rollup/rollup-linux-loong64-gnu': 4.52.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.3
+      '@rollup/rollup-linux-riscv64-musl': 4.52.3
+      '@rollup/rollup-linux-s390x-gnu': 4.52.3
+      '@rollup/rollup-linux-x64-gnu': 4.52.3
+      '@rollup/rollup-linux-x64-musl': 4.52.3
+      '@rollup/rollup-openharmony-arm64': 4.52.3
+      '@rollup/rollup-win32-arm64-msvc': 4.52.3
+      '@rollup/rollup-win32-ia32-msvc': 4.52.3
+      '@rollup/rollup-win32-x64-gnu': 4.52.3
+      '@rollup/rollup-win32-x64-msvc': 4.52.3
+      fsevents: 2.3.3
+    dev: true
+
+  /scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
+
+  /source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /vite@5.4.20:
+    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.52.3
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,7 @@
+import RecordingsPage from "./pages/RecordingsPage";
+
+function App(): JSX.Element {
+  return <RecordingsPage />;
+}
+
+export default App;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,0 +1,67 @@
+import type {
+  ApiErrorPayload,
+  DownloadResponsePayload,
+  DownloadTrigger,
+  RecordingSummary,
+  RecordingsQuery
+} from "./types";
+
+export class ApiClientError extends Error {
+  status: number;
+  code?: string | null;
+
+  constructor(message: string, status: number, code?: string | null) {
+    super(message);
+    this.name = "ApiClientError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+async function request<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {})
+    },
+    ...init
+  });
+
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : null;
+
+  if (!response.ok) {
+    const payload = data as ApiErrorPayload | null;
+    const message = payload?.message ?? `Request failed with status ${response.status}`;
+    throw new ApiClientError(message, response.status, payload?.code ?? null);
+  }
+
+  return data as T;
+}
+
+export async function fetchRecordings(params: RecordingsQuery): Promise<RecordingSummary[]> {
+  const search = new URLSearchParams();
+  if (params.from) {
+    search.append("from", params.from);
+  }
+  if (params.to) {
+    search.append("to", params.to);
+  }
+  if (params.hostEmail) {
+    search.append("host_email", params.hostEmail);
+  }
+  if (params.meetingId) {
+    search.append("meeting_id", params.meetingId);
+  }
+
+  const url = `/api/recordings${search.toString() ? `?${search.toString()}` : ""}`;
+  return request<RecordingSummary[]>(url, { method: "GET" });
+}
+
+export async function triggerDownload(payload: DownloadTrigger): Promise<DownloadResponsePayload> {
+  return request<DownloadResponsePayload>("/api/download", {
+    method: "POST",
+    body: JSON.stringify(payload)
+  });
+}

--- a/web/src/components/RecordingTable.tsx
+++ b/web/src/components/RecordingTable.tsx
@@ -1,0 +1,101 @@
+import type { RecordingSummary } from "../types";
+
+interface RecordingTableProps {
+  recordings: RecordingSummary[];
+  pendingDownloads: Set<string>;
+  onDownload: (recording: RecordingSummary) => void;
+}
+
+function formatBytes(size: number): string {
+  if (!size) {
+    return "—";
+  }
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = size;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(value < 10 && unitIndex > 0 ? 1 : 0)} ${units[unitIndex]}`;
+}
+
+function formatDuration(minutes: number | null): string {
+  if (minutes == null) {
+    return "—";
+  }
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder ? `${hours}h ${remainder}m` : `${hours}h`;
+}
+
+const RecordingTable = ({ recordings, pendingDownloads, onDownload }: RecordingTableProps): JSX.Element => {
+  if (!recordings.length) {
+    return (
+      <div className="empty-state">
+        <strong>No recordings yet.</strong>
+        Adjust your filters and try again.
+      </div>
+    );
+  }
+
+  return (
+    <div className="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Topic</th>
+            <th>Host</th>
+            <th>Start</th>
+            <th>Duration</th>
+            <th>Assets</th>
+            <th>Total Size</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {recordings.map((recording) => {
+            const pending = pendingDownloads.has(recording.uuid);
+            const host = recording.host_email ?? "—";
+            const startDate = new Date(recording.start_time);
+            return (
+              <tr key={recording.uuid}>
+                <td>
+                  <div>{recording.topic || "Untitled"}</div>
+                  <div className="badge muted">UUID {recording.uuid}</div>
+                </td>
+                <td>{host}</td>
+                <td>{startDate.toLocaleString()}</td>
+                <td>{formatDuration(recording.duration_minutes)}</td>
+                <td>
+                  <span className="badge">{recording.asset_count}</span>
+                </td>
+                <td>{formatBytes(recording.total_size_bytes)}</td>
+                <td>
+                  <div className="recording-actions">
+                    <button
+                      type="button"
+                      onClick={() => onDownload(recording)}
+                      disabled={pending}
+                    >
+                      {pending ? "Downloading…" : "Download"}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <div className="table-footer">
+        <span>{recordings.length} result{recordings.length === 1 ? "" : "s"}</span>
+        <span>Downloads run through the server; credentials stay on the backend.</span>
+      </div>
+    </div>
+  );
+};
+
+export default RecordingTable;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,248 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0b0b0f;
+  color: #f5f5f7;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(160deg, #101620 0%, #111319 40%, #0b0b0f 100%);
+}
+
+a {
+  color: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+button {
+  cursor: pointer;
+}
+
+input,
+select,
+button {
+  font: inherit;
+}
+
+.container {
+  margin: 0 auto;
+  max-width: 1100px;
+  padding: 2.5rem 1.75rem 4rem;
+}
+
+.card {
+  background-color: rgba(17, 25, 40, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(15, 15, 25, 0.65);
+  backdrop-filter: blur(20px);
+}
+
+.card-header {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1.75rem 2rem 1.25rem;
+}
+
+.card-body {
+  padding: 2rem;
+}
+
+.card-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1.25rem 2rem;
+  font-size: 0.875rem;
+  color: rgba(245, 245, 247, 0.7);
+}
+
+.filters-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.filters-grid label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: rgba(245, 245, 247, 0.65);
+}
+
+.filters-grid input {
+  margin-top: 0.35rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: 11px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(10, 12, 19, 0.92);
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filters-grid input:focus {
+  border-color: rgba(94, 129, 255, 0.65);
+  box-shadow: 0 0 0 2px rgba(94, 129, 255, 0.2);
+  outline: none;
+}
+
+.actions {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.primary-button,
+.secondary-button {
+  border: none;
+  border-radius: 12px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #5e81ff, #8ca6ff);
+  color: #0b0b0f;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.primary-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(94, 129, 255, 0.4);
+}
+
+.secondary-button {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(245, 245, 247, 0.85);
+}
+
+.tagline {
+  margin: 0;
+  color: rgba(245, 245, 247, 0.6);
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.status-banner {
+  margin-bottom: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  font-size: 0.95rem;
+}
+
+.status-banner.success {
+  background: rgba(82, 196, 26, 0.16);
+  border: 1px solid rgba(82, 196, 26, 0.35);
+  color: #b7ffb0;
+}
+
+.status-banner.error {
+  background: rgba(255, 77, 79, 0.18);
+  border: 1px solid rgba(255, 99, 104, 0.35);
+  color: #ffd1d4;
+}
+
+.status-banner.info {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: rgba(245, 245, 247, 0.8);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  color: rgba(245, 245, 247, 0.92);
+}
+
+thead th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+  padding: 0.75rem 1rem;
+  color: rgba(245, 245, 247, 0.65);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+
+tbody td {
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+tbody tr:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border-radius: 999px;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.75rem;
+  background: rgba(94, 129, 255, 0.2);
+  color: rgba(211, 220, 255, 0.95);
+}
+
+.badge.muted {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(245, 245, 247, 0.7);
+}
+
+.recording-actions {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.recording-actions button {
+  background: rgba(94, 129, 255, 0.18);
+  border: 1px solid rgba(94, 129, 255, 0.35);
+  border-radius: 10px;
+  color: rgba(177, 192, 255, 0.95);
+  padding: 0.45rem 0.95rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.recording-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.empty-state {
+  margin: 2.5rem auto;
+  text-align: center;
+  color: rgba(245, 245, 247, 0.65);
+}
+
+.empty-state strong {
+  display: block;
+  margin-bottom: 0.4rem;
+  font-size: 1rem;
+}
+
+.table-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1.5rem;
+  font-size: 0.85rem;
+  color: rgba(245, 245, 247, 0.65);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/web/src/pages/RecordingsPage.tsx
+++ b/web/src/pages/RecordingsPage.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+
+import { fetchRecordings, triggerDownload, ApiClientError } from "../api";
+import RecordingTable from "../components/RecordingTable";
+import type { RecordingSummary } from "../types";
+
+interface BannerState {
+  kind: "info" | "success";
+  message: string;
+}
+
+const daysBetween = 30;
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function defaultFrom(): string {
+  const now = new Date();
+  const prior = new Date(now.getTime() - daysBetween * 24 * 60 * 60 * 1000);
+  return formatDate(prior);
+}
+
+function defaultTo(): string {
+  return formatDate(new Date());
+}
+
+const RecordingsPage = (): JSX.Element => {
+  const [from, setFrom] = useState<string>(defaultFrom);
+  const [to, setTo] = useState<string>(defaultTo);
+  const [hostEmail, setHostEmail] = useState<string>("");
+  const [meetingId, setMeetingId] = useState<string>("");
+  const [records, setRecords] = useState<RecordingSummary[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [banner, setBanner] = useState<BannerState | null>(null);
+  const [pendingDownloads, setPendingDownloads] = useState<Set<string>>(new Set());
+
+  const query = useMemo(
+    () => ({
+      from: from || undefined,
+      to: to || undefined,
+      hostEmail: hostEmail.trim() || undefined,
+      meetingId: meetingId.trim() || undefined
+    }),
+    [from, to, hostEmail, meetingId]
+  );
+
+  const loadRecordings = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setBanner(null);
+    try {
+      const data = await fetchRecordings(query);
+      setRecords(data);
+      if (!data.length) {
+        setBanner({ kind: "info", message: "No recordings matched your filters." });
+      }
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        setError(err.message);
+      } else {
+        setError("Failed to load recordings. Please retry.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [query]);
+
+  useEffect(() => {
+    void loadRecordings();
+  }, [loadRecordings]);
+
+  const resetFilters = () => {
+    setFrom(defaultFrom());
+    setTo(defaultTo());
+    setHostEmail("");
+    setMeetingId("");
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await loadRecordings();
+  };
+
+  const handleDownload = async (recording: RecordingSummary) => {
+    const identifier = recording.uuid;
+    setPendingDownloads((prev) => {
+      const next = new Set(prev);
+      next.add(identifier);
+      return next;
+    });
+    setError(null);
+    setBanner(null);
+    try {
+      const response = await triggerDownload({ meeting_id_or_uuid: identifier });
+      const note = response.note ?? `Download triggered for ${recording.topic || recording.uuid}.`;
+      setBanner({ kind: "success", message: note });
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        setError(err.message);
+      } else {
+        setError("Download failed. Inspect server logs for details.");
+      }
+    } finally {
+      setPendingDownloads((prev) => {
+        const next = new Set(prev);
+        next.delete(identifier);
+        return next;
+      });
+    }
+  };
+
+  return (
+    <div className="container">
+      <div className="card">
+        <div className="card-header">
+          <h1>ZoomScribe Web</h1>
+          <p className="tagline">Browse Zoom cloud recordings and trigger downloads on your server.</p>
+        </div>
+        <div className="card-body">
+          {error && <div className="status-banner error">{error}</div>}
+          {banner && <div className={`status-banner ${banner.kind}`}>{banner.message}</div>}
+
+          <form className="filters" onSubmit={handleSubmit}>
+            <div className="filters-grid">
+              <label>
+                From
+                <input
+                  type="date"
+                  value={from}
+                  onChange={(event) => setFrom(event.target.value)}
+                  max={to || undefined}
+                />
+              </label>
+              <label>
+                To
+                <input
+                  type="date"
+                  value={to}
+                  onChange={(event) => setTo(event.target.value)}
+                  min={from || undefined}
+                />
+              </label>
+              <label>
+                Host Email
+                <input
+                  type="email"
+                  placeholder="host@example.com"
+                  value={hostEmail}
+                  onChange={(event) => setHostEmail(event.target.value)}
+                />
+              </label>
+              <label>
+                Meeting ID or UUID
+                <input
+                  type="text"
+                  placeholder="Zoom meeting UUID"
+                  value={meetingId}
+                  onChange={(event) => setMeetingId(event.target.value)}
+                />
+              </label>
+            </div>
+            <div className="actions">
+              <button className="primary-button" type="submit" disabled={loading}>
+                {loading ? "Searching…" : "Search"}
+              </button>
+              <button className="secondary-button" type="button" onClick={resetFilters} disabled={loading}>
+                Reset
+              </button>
+            </div>
+          </form>
+
+          <RecordingTable
+            recordings={records}
+            pendingDownloads={pendingDownloads}
+            onDownload={handleDownload}
+          />
+        </div>
+        <div className="card-footer">
+          FastAPI enforces server-side OAuth. Secrets stay on the backend; the browser only sees summaries.
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RecordingsPage;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,34 @@
+export interface RecordingSummary {
+  uuid: string;
+  meeting_id: string | null;
+  topic: string;
+  host_email: string | null;
+  start_time: string;
+  duration_minutes: number | null;
+  asset_count: number;
+  total_size_bytes: number;
+}
+
+export interface ApiErrorPayload {
+  message: string;
+  code?: string | null;
+}
+
+export interface RecordingsQuery {
+  from?: string;
+  to?: string;
+  hostEmail?: string;
+  meetingId?: string;
+}
+
+export interface DownloadTrigger {
+  meeting_id_or_uuid: string;
+  overwrite?: boolean;
+  target_dir?: string;
+}
+
+export interface DownloadResponsePayload {
+  ok: boolean;
+  files_expected: number;
+  note?: string | null;
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": "./",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true
+      }
+    }
+  },
+  build: {
+    outDir: "dist"
+  }
+});


### PR DESCRIPTION
## Summary
- add `zoom_scribe.web_api` FastAPI service that reuses the existing client/downloader and serves static assets
- expose typed DTOs plus pytest coverage for health, listings, and download triggers
- scaffold a Vite + React frontend to filter recordings and trigger downloads via the new backend

## Testing
- .venv/bin/pytest

## Risk
Medium – synchronous downloads can block requests and meeting IDs aren’t yet exposed in summaries.

## Checklist
- [x] Updated docs
- [x] Added tests
- [x] Ran frontend install to produce lockfile
